### PR TITLE
Add required dependencies to readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ Sparse Autoencoders (SAEs) are widely used in mechanistic interpretability, but 
 First, install the required Python libraries:
 
 ```
-pip install torch numpy matplotlib tqdm scikit-learn scipy pyvista
+pip install torch numpy matplotlib tqdm scikit-learn scipy pyvista transformers datasets
 
 ```
 ---


### PR DESCRIPTION
Running `exp_e3_LLM_SGD_PAM_ablations.py` requires the modules `transformers` and `datasets`, which were missing in the readme.